### PR TITLE
Add new alias to unstaging a staged file

### DIFF
--- a/dot-files/.gitconfig
+++ b/dot-files/.gitconfig
@@ -138,6 +138,10 @@
 	# Same as `a` but include new files also: $ git aa
 	aa = "!git add -A && git ss"
 
+	# Unstaging a file: $ git unstage myfile
+	# equivalent to: $ git reset HEAD myfile
+	unstage = "reset HEAD --"
+
 	# Commit shortcut with message: $ git cm "Commit message"
 	cm = commit -m
 


### PR DESCRIPTION
"[...] to correct the usability problem you encountered with unstaging a file, you can add your own unstage alias to Git".

Example:
---
![captura de pantalla de 2018-02-20 10-42-05](https://user-images.githubusercontent.com/10713284/36428370-a8980a0e-1647-11e8-89ed-359105c9d9ed.png)

Reference:
----
https://git-scm.com/book/en/v1/Git-Basics-Tips-and-Tricks